### PR TITLE
fix #37: Change install package method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /home/jovyan/nlpia
 COPY . .
 
 RUN pip install --upgrade pip
-RUN pip install -r requirements.txt
 RUN pip install -e .
 
 WORKDIR /home/jovyan


### PR DESCRIPTION
Change pip install to the same way with 5.2

![image](https://user-images.githubusercontent.com/5634477/99900430-187cdf80-2ce2-11eb-9aec-2c7863b82e2c.png)

Issue:
https://github.com/totalgood/nlpia/issues/37